### PR TITLE
Security Fix for Prototype Pollution - huntr.dev

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,10 @@
 export default function (obj, keys, val) {
 	keys.split && (keys=keys.split('.'));
-	var i=0, l=keys.length, t=obj, x;
+	var i=0, l=keys.length, t=obj, x, k;
 	for (; i < l; ++i) {
-		if (isPrototypePolluted(keys[i])) continue;
-		x = t[keys[i]];
-		t = t[keys[i]] = (i === l - 1 ? val : (x != null ? x : (!!~keys[i+1].indexOf('.') || !(+keys[i+1] > -1)) ? {} : []));
+		k = keys[i];
+		if (k == '__proto__' || k == 'constructor' || k == 'prototype') continue;
+		x = t[k];
+		t = t[k] = (i === l - 1 ? val : (x != null ? x : (!!~keys[i+1].indexOf('.') || !(+keys[i+1] > -1)) ? {} : []));
 	}
-}
-
-function isPrototypePolluted(key) {
-    return ['__proto__', 'constructor', 'prototype'].includes(key);
 }


### PR DESCRIPTION
https://huntr.dev/users/arjunshibu has fixed the Prototype Pollution vulnerability 🔨. Think you could fix a vulnerability like this?

Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/dset/pull/1
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/npm/dset/1/README.md

### User Comments:

### :bar_chart: Metadata *

`dset` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-dset

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
var dset = require("dset")
var obj = {}
console.log("Before : " + {}.polluted);
dset(obj, '__proto__.polluted', 'Yes! Its Polluted');
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i dset # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before: undefined
After: Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

![dset](https://user-images.githubusercontent.com/43996156/104118622-7a57de00-5350-11eb-8f8b-e5a9a0e38b6c.PNG)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
