### PR TITLE
docs: reference correct build status

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# dset [![CI]((https://github.com/lukeed/dset/workflows/CI/badge.svg?event=push&query=workflow:CI+branch:master)](https://github.com/lukeed/dset/actions?query=workflow:CI+branch:master) [![codecov](https://badgen.net/codecov/c/github/lukeed/dset)](https://codecov.io/gh/lukeed/dset)
+# dset [![CI](https://github.com/lukeed/dset/workflows/CI/badge.svg?branch=master&event=push)](https://github.com/lukeed/dset/actions) [![codecov](https://badgen.net/codecov/c/github/lukeed/dset)](https://codecov.io/gh/lukeed/dset)
 
 > A tiny (160B) utility for safely writing deep Object values~!
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# dset [![CI](https://github.com/lukeed/dset/workflows/CI/badge.svg)](https://github.com/lukeed/dset/actions?query=workflow%3ACI) [![codecov](https://badgen.net/codecov/c/github/lukeed/dset)](https://codecov.io/gh/lukeed/dset)
+# dset [![CI]((https://github.com/lukeed/dset/workflows/CI/badge.svg?event=push&query=workflow:CI+branch:master)](https://github.com/lukeed/dset/actions?query=workflow:CI+branch:master) [![codecov](https://badgen.net/codecov/c/github/lukeed/dset)](https://codecov.io/gh/lukeed/dset)
 
 > A tiny (160B) utility for safely writing deep Object values~!
 


### PR DESCRIPTION
This is so that it doesnt just pick the _latest_ workflow ci's status, like ci for other branches/pr's perhaps. But strictly that of the master branch.