### PR TITLE
fixed issue#33 CVE-2022-25645 added test for it

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "set"
   ],
   "devDependencies": {
-    "bundt": "1.1.2",
+    "bundt": "1.1.5",
     "esm": "3.2.25",
-    "uvu": "0.5.1"
+    "uvu": "0.5.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "set"
   ],
   "devDependencies": {
-    "bundt": "1.1.5",
+    "bundt": "1.1.2",
     "esm": "3.2.25",
-    "uvu": "0.5.3"
+    "uvu": "0.5.1"
   }
 }

--- a/src/merge.js
+++ b/src/merge.js
@@ -6,6 +6,7 @@ export function merge(a, b, k) {
 			}
 		} else {
 			for (k in b) {
+				if (k === '__proto__' || k === 'constructor' || k === 'prototype') break;
 				a[k] = merge(a[k], b[k]);
 			}
 		}

--- a/test/suites/pollution.js
+++ b/test/suites/pollution.js
@@ -85,5 +85,18 @@ export default function (dset) {
 		});
 	});
 
+	// Test for CVE-2022-25645 - CWE-1321 
+	pollution(
+		"should ignore JSON.parse crafted object including __proto__ :: provided by snyk",
+		() => {
+			var a = { b: { c: 1 } };
+			assert.is(a.polluted, undefined);
+			assert.is({}.polluted, undefined);
+			dset(a, "b", JSON.parse('{"__proto__":{"polluted":"Yes!"}}')); //Needs to craft payload with JSON.parse to keep the object key proto
+			assert.is(a.polluted, undefined);
+			assert.is({}.polluted, undefined);
+		}
+	);
+
 	pollution.run();
 }

--- a/test/suites/pollution.js
+++ b/test/suites/pollution.js
@@ -86,17 +86,14 @@ export default function (dset) {
 	});
 
 	// Test for CVE-2022-25645 - CWE-1321 
-	pollution(
-		"should ignore JSON.parse crafted object including __proto__ :: provided by snyk",
-		() => {
-			var a = { b: { c: 1 } };
-			assert.is(a.polluted, undefined);
-			assert.is({}.polluted, undefined);
-			dset(a, "b", JSON.parse('{"__proto__":{"polluted":"Yes!"}}')); //Needs to craft payload with JSON.parse to keep the object key proto
-			assert.is(a.polluted, undefined);
-			assert.is({}.polluted, undefined);
-		}
-	);
+	pollution('should ignore JSON.parse crafted object with "__proto__" key', () => {
+		let a = { b: { c: 1 } };
+		assert.is(a.polluted, undefined);
+		assert.is({}.polluted, undefined);
+		dset(a, "b", JSON.parse('{"__proto__":{"polluted":"Yes!"}}'));
+		assert.is(a.polluted, undefined);
+		assert.is({}.polluted, undefined);
+	});
 
 	pollution.run();
 }


### PR DESCRIPTION
# [#33 CVE-2022-25645](https://github.com/lukeed/dset/issues/33)

Firstly added tests with [snyk provided code example](https://security.snyk.io/vuln/SNYK-JS-DSET-2330881)
and fixed the missing prototype pollution checks.

## References:
___
Source: CERT
Name: https://github.com/lukeed/dset/blob/master/src/merge.js%23L9
Url: https://github.com/lukeed/dset/blob/master/src/merge.js%23L9
___
Source: CERT
Name: https://snyk.io/vuln/SNYK-JS-DSET-2330881
Url: https://snyk.io/vuln/SNYK-JS-DSET-2330881
___
Source: CERT
Name: https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-2431974
Url: https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-2431974